### PR TITLE
ci: add postUpdateOptions for poetry-lock in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
       "matchManagers": [
         "poetry"
       ],
+      "postUpdateOptions": [
+        "poetry-lock"
+      ],
       "matchDatasources": [
         "pypi"
       ],
@@ -22,6 +25,9 @@
     {
       "matchManagers": [
         "poetry"
+      ],
+      "postUpdateOptions": [
+        "poetry-lock"
       ],
       "matchDatasources": [
         "pypi"


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to include a new `postUpdateOptions` setting for the `poetry` manager. This ensures that the `poetry-lock` file is updated after dependency updates.

Configuration updates:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R11-R13): Added `"postUpdateOptions": ["poetry-lock"]` to the `poetry` manager configuration to ensure the lock file is updated during dependency updates. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R11-R13) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R29-R31)
 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
