### PR TITLE
ci: migrate workflows to reusable + align config/metadata with template

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,37 +1,16 @@
 ---
 name: ActionLint
 on:
-  # Run on push to main/master branch
   push:
     branches: [main]
-  # Run on all pull requests
   pull_request:
     branches: ['**']
-  # Allow manual triggering
   workflow_dispatch:
-permissions:
-  contents: read
+permissions: {}
 jobs:
   actionlint:
-    name: Check GitHub Actions Workflows
-    runs-on: ubuntu-latest
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-actionlint.yml@main
     permissions:
       checks: write
       contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-      - name: Run actionlint
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d  # v1.72.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Report all findings as annotations directly on GitHub
-          reporter: github-check
-          # Error on warnings as well as errors
-          fail_level: error
-          # Comment on the pull request
-          level: error
-          filter_mode: nofilter
+      pull-requests: read

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,14 @@
+---
+name: Add issue to project
+on:
+  issues:
+    types: [opened]
+permissions: {}
+jobs:
+  add-to-project:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-add-issue-to-project.yml@main
+    secrets:
+      POLARION_GITHUB_APP_ID: ${{ secrets.POLARION_GITHUB_APP_ID }}
+      POLARION_GITHUB_APP_PRIVATE_KEY: ${{ secrets.POLARION_GITHUB_APP_PRIVATE_KEY }}
+    with:
+      project-number: ${{ vars.POLARION_GITHUB_PROJECT_NUMBER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,14 @@ jobs:
           format: tty
   release-please:
     needs: verify-with-tox
-    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' && github.ref_name == 'main'
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please.yml@main
     permissions:
       contents: write
       pull-requests: write
-      issues: write
-    steps:
-      - name: 🚀 release-please
-        id: release
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5
-        with:
-          release-type: simple
-          include-v-in-tag: false
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      version: ${{ steps.release.outputs.version }}
+    with:
+      release-type: simple
+      include-v-in-tag: false
   docker-build-and-publish:
     needs: release-please
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,95 +2,19 @@
 name: Claude Code Review
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
-      - reopened
-    # Only run on code, config, and infrastructure changes
-    paths:
-      - app/**/*.py
-      - tests/**/*.py
-      - Dockerfile
-      - docker-compose.yml
-      - tox.ini
-      - pyproject.toml
-      - uv.lock
-      - '!**/*.md'
+    types: [opened, synchronize, ready_for_review, reopened]
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+permissions: {}
 jobs:
   claude-review:
-    # Skip Claude review for Renovate, Dependabot PRs, and fork PRs
-    if: |
-      github.event.pull_request.user.login != 'renovate[bot]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main
     permissions:
-      contents: read  # Security: read-only sufficient for reviews
+      actions: read
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 1
-          persist-credentials: false  # Security: don't persist credentials
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e  # v1.0.123
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-            STEP 1: Read CLAUDE.md and any files it references to learn project
-            conventions, architecture decisions, and review standards.
-            STEP 2: Review the PR diff. Report ONLY actual problems in changed lines.
-            CONFIDENCE RULE: For each potential issue, assess confidence 0-100.
-            Only report issues scoring >= 80. If uncertain, do not flag it.
-            False positives waste reviewer time.
-            For CLAUDE.md violations: verify the rule exists and quote it.
-            Pre-existing issues on unchanged lines: ignore.
-            FOCUS ON:
-            - Bugs or logic errors
-            - Security vulnerabilities (SQL injection, XSS, auth bypass, secrets exposure)
-            - Breaking changes not mentioned in PR description
-            - Clear CLAUDE.md violations (cite the specific rule)
-            - Missing null/error handling in new code paths
-            - Missing tests for new functionality
-            - Critical performance issues introduced by changes
-            DO NOT:
-            - Review unchanged code, style/formatting, or optional improvements
-            - Run build tools
-            - Check external dependency versions
-            - Provide praise or summaries of what the code does
-            GUIDELINES:
-            - Use Read/Grep/Glob to search the codebase for context
-            - The PR branch is already checked out
-            - Cite issues using GitHub links: https://github.com/${{ github.repository }}/blob/FULL_GIT_SHA/path/to/file#L1-L2
-            - Post the full review with `gh pr comment --repo ${{ github.repository }} --body "..."`
-            - Only post GitHub comments — don't submit review text as messages
-            FORMAT (be TERSE):
-            If issues found:
-            ## ❌ Issues Found
-            1. [link] - Problem [CLAUDE.md: "rule" if applicable] - Fix: specific solution
-            2. [link] - Issue - Suggestion: specific fix
-            If NO issues found: "## ✅ No issues found. Checked for bugs and CLAUDE.md compliance."
-          settings: |
-            {
-              "permissions": {
-                "allow": [
-                  "Read", "Grep", "Glob", "BatchTool",
-                  "Bash(gh pr comment:*)",
-                  "Bash(gh pr diff:*)",
-                  "Bash(gh pr view:*)",
-                  "Bash(gh api:*)"
-                ]
-              }
-            }
-          claude_args: --max-turns 30
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,23 +3,9 @@ name: PR checks
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, unlocked]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   check-conventional-commit:
-    name: Check commit messages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: 3.x
-      - run: pip install commitizen
-      - name: Check commit messages
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: cz check --rev-range "$BASE_SHA..$HEAD_SHA"
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-pr.yml@main
+    permissions:
+      contents: read

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  # Reusable workflows from our own org — tracking @main intentionally.
+  unpinned-uses:
+    config:
+      policies:
+        '*': hash-pin
+        SchweizerischeBundesbahnen/*: any

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,31 @@
 ---
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
+  - repo: local
+    hooks:
+      # Run the formatter
+      - id: ruff-format
+        name: ruff formatter
+        entry: uv run ruff format
+        language: system
+        types: [python]
+      # Run the linter (inherits config from pyproject.toml)
+      - id: ruff-check
+        name: ruff linter
+        entry: uv run ruff check
+        language: system
+        types: [python]
+        args: [--fix]
+        exclude: ^tests/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        args: [--maxkb=5120]
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: trailing-whitespace
+        exclude_types: [markdown]  # Avoid conflicts with markdown formatting
       - id: check-json
       - id: check-toml
       - id: check-yaml
@@ -41,12 +59,6 @@ repos:
         exclude: (^tests/)
         args: [--config-file, pyproject.toml]
         require_serial: true  # Serial processing is required for mypy (better performance and error reporting)
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
-    hooks:
-      - id: ruff-check
-        args: [--fix]
-      - id: ruff-format
   - repo: local
     hooks:
       - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Service for StrictDoc requirements management and documentation t
 authors = [
     {name = "SBB Polarion Team", email = "polarion-opensource@sbb.ch"},
 ]
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.14,<3.15"
 dependencies = [
     "strictdoc==0.20.0",
     "fastapi==0.136.1",
@@ -18,6 +18,10 @@ dependencies = [
     # pinning version to avoid security issues
     "urllib3==2.7.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/SchweizerischeBundesbahnen/strictdoc-service"
+Repository = "https://github.com/SchweizerischeBundesbahnen/strictdoc-service"
 
 [dependency-groups]
 dev = [

--- a/tests/export/conftest.py
+++ b/tests/export/conftest.py
@@ -87,6 +87,7 @@ def docker_setup() -> Generator[bool]:
     try:
         # Enable BuildKit via environment variable
         import os
+
         os.environ["DOCKER_BUILDKIT"] = "1"
         client = docker.from_env()
     except DockerException as e:
@@ -124,6 +125,7 @@ def docker_setup() -> Generator[bool]:
         logger.info("Building Docker image strictdoc-service:test")
         try:
             import subprocess
+
             result = subprocess.run(
                 ["docker", "build", "-t", "strictdoc-service:test", "."],
                 env={**os.environ, "DOCKER_BUILDKIT": "1"},

--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -118,6 +118,7 @@ class TestMetricsServerConfiguration:
         with patch.dict("os.environ", {"METRICS_PORT": "70000"}):
             # Re-import to pick up new env var
             import importlib
+
             importlib.reload(app.metrics_server)
 
             # Port should be validated to default

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -116,37 +116,46 @@ class TestSanitizationIntegration:
         assert normalized_content == "[DOCUMENT]\nTitle: Test\n\nContent here"
 
 
-@pytest.mark.parametrize("input_filename,expected", [
-    ("normal.txt", "normal.txt"),
-    ("../../../etc/passwd", "......etcpasswd"),
-    ("file with spaces.pdf", "file with spaces.pdf"),
-    ("", ""),
-    (".hidden", ".hidden"),
-    ("file<>:\"|?*.txt", "file.txt"),
-])
+@pytest.mark.parametrize(
+    "input_filename,expected",
+    [
+        ("normal.txt", "normal.txt"),
+        ("../../../etc/passwd", "......etcpasswd"),
+        ("file with spaces.pdf", "file with spaces.pdf"),
+        ("", ""),
+        (".hidden", ".hidden"),
+        ('file<>:"|?*.txt', "file.txt"),
+    ],
+)
 def test_sanitize_filename_parametrized(input_filename: str, expected: str) -> None:
     """Parametrized tests for sanitize_filename function."""
     assert sanitize_filename(input_filename) == expected
 
 
-@pytest.mark.parametrize("input_text,expected", [
-    ("normal text", "normal text"),
-    ("line1\nline2", "line1line2"),
-    ("line1\r\nline2", "line1line2"),
-    ("line1\rline2", "line1line2"),
-    ("mixed\nline\r\nendings\r", "mixedlineendings"),
-])
+@pytest.mark.parametrize(
+    "input_text,expected",
+    [
+        ("normal text", "normal text"),
+        ("line1\nline2", "line1line2"),
+        ("line1\r\nline2", "line1line2"),
+        ("line1\rline2", "line1line2"),
+        ("mixed\nline\r\nendings\r", "mixedlineendings"),
+    ],
+)
 def test_sanitize_for_logging_parametrized(input_text: str, expected: str) -> None:
     """Parametrized tests for sanitize_for_logging function."""
     assert sanitize_for_logging(input_text) == expected
 
 
-@pytest.mark.parametrize("input_content,expected", [
-    ("unix\nlines", "unix\nlines"),
-    ("windows\r\nlines", "windows\nlines"),
-    ("mac\rlines", "mac\nlines"),
-    ("mixed\nwin\r\nmac\rends", "mixed\nwin\nmac\nends"),
-])
+@pytest.mark.parametrize(
+    "input_content,expected",
+    [
+        ("unix\nlines", "unix\nlines"),
+        ("windows\r\nlines", "windows\nlines"),
+        ("mac\rlines", "mac\nlines"),
+        ("mixed\nwin\r\nmac\rends", "mixed\nwin\nmac\nends"),
+    ],
+)
 def test_normalize_line_endings_parametrized(input_content: str, expected: str) -> None:
     """Parametrized tests for normalize_line_endings function."""
     assert normalize_line_endings(input_content) == expected

--- a/tests/test_strictdoc_controller.py
+++ b/tests/test_strictdoc_controller.py
@@ -505,7 +505,7 @@ async def test_successful_validation_with_safe_paths() -> None:
             mock_validate.return_value = None
 
             # Call the function with a safe filename
-            result = await export_document(sdoc_content="[DOCUMENT]\nTITLE: Test\n", format="sdoc", file_name="safe_document")
+            await export_document(sdoc_content="[DOCUMENT]\nTITLE: Test\n", format="sdoc", file_name="safe_document")
 
             # Verify the validation was called and file was copied
             mock_validate.assert_called_once()

--- a/tests/test_strictdoc_controller.py
+++ b/tests/test_strictdoc_controller.py
@@ -318,9 +318,7 @@ async def test_export_to_format_html_zip() -> None:
         (html_dir / "index.html").write_text("<html>Test</html>")
 
         with patch("app.strictdoc_controller.export_with_action"):
-            result_file, extension, mime_type = await export_to_format(
-                input_file, output_dir, "html"
-            )
+            result_file, extension, mime_type = await export_to_format(input_file, output_dir, "html")
 
             assert extension == "zip"
             assert mime_type == "application/zip"
@@ -409,16 +407,8 @@ async def test_path_validation_with_invalid_export_file() -> None:
 
             # Test with modified approach that doesn't require mocking Path.resolve
             # Instead, use an actual path that would fail validation
-            with patch("tempfile.gettempdir", return_value=str(temp_dir_path)), \
-                 patch("shutil.copy2"), \
-                 patch("app.strictdoc_controller.FileResponse"), \
-                 pytest.raises(HTTPException) as excinfo:
-
-                await export_document(
-                    sdoc_content="[DOCUMENT]\nTITLE: Test\n",
-                    format="sdoc",
-                    file_name="test_document"
-                )
+            with patch("tempfile.gettempdir", return_value=str(temp_dir_path)), patch("shutil.copy2"), patch("app.strictdoc_controller.FileResponse"), pytest.raises(HTTPException) as excinfo:
+                await export_document(sdoc_content="[DOCUMENT]\nTITLE: Test\n", format="sdoc", file_name="test_document")
 
             # Verify that an exception was raised - either BAD_REQUEST for path validation
             # or INTERNAL_SERVER_ERROR if the path traversal is caught elsewhere
@@ -471,11 +461,14 @@ async def test_sanitize_filename_is_called() -> None:
         export_file = temp_dir_path / "test.sdoc"
         export_file.write_text("test content")
 
-        with patch("app.strictdoc_controller.export_to_format") as mock_export, patch(
-            "app.strictdoc_controller.sanitize_filename"
-        ) as mock_sanitize, patch("app.strictdoc_controller.validate_export_paths"), patch(
-            "tempfile.gettempdir", return_value=str(temp_dir_path)
-        ), patch("shutil.copy2"), patch("app.strictdoc_controller.FileResponse"):
+        with (
+            patch("app.strictdoc_controller.export_to_format") as mock_export,
+            patch("app.strictdoc_controller.sanitize_filename") as mock_sanitize,
+            patch("app.strictdoc_controller.validate_export_paths"),
+            patch("tempfile.gettempdir", return_value=str(temp_dir_path)),
+            patch("shutil.copy2"),
+            patch("app.strictdoc_controller.FileResponse"),
+        ):
             # Mock export_to_format to return a valid file
             mock_export.return_value = (export_file, "sdoc", "text/plain")
             mock_sanitize.return_value = "safe_filename"
@@ -498,12 +491,13 @@ async def test_successful_validation_with_safe_paths() -> None:
         # Create the export file so stat() works
         output_file.write_text("test content")
 
-        with patch("app.strictdoc_controller.export_to_format") as mock_export, \
-             patch("tempfile.gettempdir", return_value=str(temp_dir_path)), \
-             patch("app.strictdoc_controller.validate_export_paths") as mock_validate, \
-             patch("shutil.copy2") as mock_copy, \
-             patch("app.strictdoc_controller.FileResponse") as mock_response:
-
+        with (
+            patch("app.strictdoc_controller.export_to_format") as mock_export,
+            patch("tempfile.gettempdir", return_value=str(temp_dir_path)),
+            patch("app.strictdoc_controller.validate_export_paths") as mock_validate,
+            patch("shutil.copy2") as mock_copy,
+            patch("app.strictdoc_controller.FileResponse") as mock_response,
+        ):
             # Mock export_to_format to return a valid file
             mock_export.return_value = (output_file, "sdoc", "text/plain")
 
@@ -511,11 +505,7 @@ async def test_successful_validation_with_safe_paths() -> None:
             mock_validate.return_value = None
 
             # Call the function with a safe filename
-            result = await export_document(
-                sdoc_content="[DOCUMENT]\nTITLE: Test\n",
-                format="sdoc",
-                file_name="safe_document"
-            )
+            result = await export_document(sdoc_content="[DOCUMENT]\nTITLE: Test\n", format="sdoc", file_name="safe_document")
 
             # Verify the validation was called and file was copied
             mock_validate.assert_called_once()
@@ -534,21 +524,18 @@ async def test_path_normalization() -> None:
         # Create the export file so stat() works
         output_file.write_text("test content")
 
-        with patch("app.strictdoc_controller.export_to_format") as mock_export, \
-             patch("app.strictdoc_controller.validate_export_paths") as mock_validate, \
-             patch("tempfile.gettempdir", return_value=str(temp_dir_path)), \
-             patch("shutil.copy2") as mock_copy, \
-             patch("app.strictdoc_controller.FileResponse") as mock_response:
-
+        with (
+            patch("app.strictdoc_controller.export_to_format") as mock_export,
+            patch("app.strictdoc_controller.validate_export_paths") as mock_validate,
+            patch("tempfile.gettempdir", return_value=str(temp_dir_path)),
+            patch("shutil.copy2") as mock_copy,
+            patch("app.strictdoc_controller.FileResponse") as mock_response,
+        ):
             # Mock export_to_format to return a valid file
             mock_export.return_value = (output_file, "txt", "text/plain")
 
             # Call the function - should succeed without exceptions
-            await export_document(
-                sdoc_content="[DOCUMENT]\nTITLE: Test\n",
-                format="txt",
-                file_name="output_file"
-            )
+            await export_document(sdoc_content="[DOCUMENT]\nTITLE: Test\n", format="txt", file_name="output_file")
 
             # Verify the file was copied and response was created
             mock_copy.assert_called_once()

--- a/tests/test_uvloop_compatibility.py
+++ b/tests/test_uvloop_compatibility.py
@@ -58,11 +58,7 @@ def test_uvloop_event_loop_functionality() -> None:
         print(f"✅ uvloop event loop functional on Python {python_version.major}.{python_version.minor}.{python_version.micro}")
 
     except Exception as e:
-        pytest.fail(
-            f"❌ uvloop event loop FAILED on Python {python_version.major}.{python_version.minor}\n\n"
-            f"Error: {e}\n\n"
-            f"uvloop imported successfully but failed to function as an event loop."
-        )
+        pytest.fail(f"❌ uvloop event loop FAILED on Python {python_version.major}.{python_version.minor}\n\nError: {e}\n\nuvloop imported successfully but failed to function as an event loop.")
 
 
 def test_uvicorn_has_uvloop_extras() -> None:
@@ -73,13 +69,9 @@ def test_uvicorn_has_uvloop_extras() -> None:
     """
     try:
         import uvloop  # noqa: F401
+
         has_uvloop = True
     except ImportError:
         has_uvloop = False
 
-    assert has_uvloop, (
-        "uvloop is not available. This means either:\n"
-        "1. uvicorn was installed without [standard] extras, OR\n"
-        "2. uvloop failed to install/compile\n\n"
-        "Expected dependency: uvicorn[standard] which includes uvloop"
-    )
+    assert has_uvloop, "uvloop is not available. This means either:\n1. uvicorn was installed without [standard] extras, OR\n2. uvloop failed to install/compile\n\nExpected dependency: uvicorn[standard] which includes uvloop"

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,10 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
+requires-python = "==3.14.*"
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'emscripten'",
-    "python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions workflows to centralized reusable workflows from [github-workflows-polarion](https://github.com/SchweizerischeBundesbahnen/github-workflows-polarion).
- Sync pre-commit config and `pyproject.toml` metadata with [open-source-polarion-docker-repo-template](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-docker-repo-template).

## Workflow migration (#94)
- `actionlint.yml` → `reusable-actionlint.yml`
- `pr.yml` → `reusable-pr.yml`
- `claude-code-review.yml` → `reusable-claude-code-review.yml` (drops the inline prompt and Renovate/Dependabot filter — both now live in the reusable workflow)
- `ci.yml` release-please job → `reusable-release-please.yml`
- New `add-issue-to-project.yml` calling `reusable-add-issue-to-project.yml`
- New `.github/zizmor.yml` so the unpinned `@main` ref to our own org's reusable workflows passes the zizmor pre-commit hook (mirrors weasyprint-service).

## Template alignment (#95)
- **pre-commit**: replace remote `astral-sh/ruff-pre-commit` block with local `uv run ruff format` / `uv run ruff check` hooks (versions now track the dev-group pin). Add `--maxkb=5120` to `check-added-large-files` and `exclude_types: [markdown]` to `trailing-whitespace`. Resulting ruff format fixes applied to `tests/`.
  - The `python-sbb-polarion-linter` hook from the template is intentionally omitted — it expects the `python_sbb_polarion/` module which strictdoc-service does not provide (weasyprint-service drops it for the same reason).
- **pyproject.toml**:
  - `license = {text = "Apache License 2.0"}` → `license = "Apache-2.0"` (SPDX)
  - `requires-python = ">=3.14"` → `">=3.14,<3.15"`
  - Add `[project.urls]` (Homepage, Repository)
  - Refresh `uv.lock` for the new Python constraint

## Intentionally not synced
- `CLAUDE.md`, `CONTRIBUTING.md`, `NOTICE` — drift is project-specific (gotchas for PDF / monkey-patch / Alpine, uv tooling section, 2024 copyright year).
- `renovate.json`, `.gitignore` — drift is project-specific (strictdoc package rules, `.claude/`, `test-*`, `*.sarif`).

## Test plan
- [x] `pre-commit run -a` passes locally
- [x] `actionlint` clean
- [x] `uv lock --check` clean
- [ ] CI green on PR
- [ ] Verify release-please reusable workflow exposes the same outputs (`release_created`, `version`) consumed by `docker-build-and-publish`

Closes #94
Closes #95