### PR TITLE
fix(security): sanitize StrictDoc subprocess output before logging

### DIFF
--- a/app/strictdoc_controller.py
+++ b/app/strictdoc_controller.py
@@ -350,7 +350,7 @@ async def run_strictdoc_command(cmd: list[str]) -> None:
             logger.warning("StrictDoc CLI warnings: %s", sanitize_for_logging(stderr_text))
 
     except Exception as e:
-        logger.exception("Command execution failed: %s", str(e))
+        logger.error("Command execution failed: %s", sanitize_for_logging(str(e)))
         raise RuntimeError(f"Command execution failed: {e!s}") from e
 
 

--- a/app/strictdoc_controller.py
+++ b/app/strictdoc_controller.py
@@ -315,7 +315,9 @@ def process_sdoc_content(content: str, input_file: Path) -> None:
             else:
                 error_msg = "Syntax error in SDOC document. Please check your document structure."
 
-        logger.exception("SDOC parsing error: %s", error_msg)
+        # Sanitize once for both the log sink and the client-facing error detail
+        error_msg = sanitize_for_logging(error_msg)
+        logger.error("SDOC parsing error: %s", error_msg)
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=error_msg) from e
 
 

--- a/app/strictdoc_controller.py
+++ b/app/strictdoc_controller.py
@@ -317,7 +317,10 @@ def process_sdoc_content(content: str, input_file: Path) -> None:
 
         # Sanitize once for both the log sink and the client-facing error detail
         error_msg = sanitize_for_logging(error_msg)
-        logger.error("SDOC parsing error: %s", error_msg)
+        # Deliberately logger.error, not logger.exception: the original parser exception's
+        # traceback would render the raw (unsanitized) document content, reintroducing the
+        # CWE-117 log injection that the error_msg sanitization above closes.
+        logger.error("SDOC parsing error: %s", error_msg)  # NOSONAR S8572
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=error_msg) from e
 
 
@@ -352,7 +355,7 @@ async def run_strictdoc_command(cmd: list[str]) -> None:
             logger.warning("StrictDoc CLI warnings: %s", sanitize_for_logging(stderr_text))
 
     except Exception as e:
-        logger.error("Command execution failed: %s", sanitize_for_logging(str(e)))
+        logger.exception("Command execution failed: %s", str(e))
         raise RuntimeError(f"Command execution failed: {e!s}") from e
 
 
@@ -372,7 +375,7 @@ async def export_with_action(input_file: Path, output_dir: Path, format_name: st
         cmd = ["strictdoc", "export", "--formats", format_name, "--output-dir", str(output_dir), str(input_file)]
         await run_strictdoc_command(cmd)
     except Exception as e:
-        logger.error("Export failed: %s", sanitize_for_logging(str(e)))
+        logger.exception("Export failed: %s", str(e))
         raise RuntimeError(f"Export failed: {e!s}") from e
 
 
@@ -404,7 +407,7 @@ async def export_to_format(input_file: Path, output_dir: Path, export_format: st
         # Call export_with_action for the actual export
         await export_with_action(input_file, output_dir, export_format)
     except Exception as e:
-        logger.error("Export failed: %s", sanitize_for_logging(str(e)))
+        logger.exception("Export failed: %s", str(e))
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=f"Export to {export_format} failed: {e!s}") from e
 
     # For HTML, we need to zip the output directory
@@ -562,7 +565,7 @@ async def export_document(
                     if persistent_temp_file.exists():
                         persistent_temp_file.unlink()
                 except Exception as e:
-                    logger.error("Failed to clean up temporary file: %s", sanitize_for_logging(str(e)))
+                    logger.exception("Failed to clean up temporary file: %s", str(e))
 
             # Record successful export metrics
             duration_ms = (time.perf_counter() - start_time) * 1000

--- a/app/strictdoc_controller.py
+++ b/app/strictdoc_controller.py
@@ -370,7 +370,7 @@ async def export_with_action(input_file: Path, output_dir: Path, format_name: st
         cmd = ["strictdoc", "export", "--formats", format_name, "--output-dir", str(output_dir), str(input_file)]
         await run_strictdoc_command(cmd)
     except Exception as e:
-        logger.exception("Export failed: %s", str(e))
+        logger.error("Export failed: %s", sanitize_for_logging(str(e)))
         raise RuntimeError(f"Export failed: {e!s}") from e
 
 
@@ -402,7 +402,7 @@ async def export_to_format(input_file: Path, output_dir: Path, export_format: st
         # Call export_with_action for the actual export
         await export_with_action(input_file, output_dir, export_format)
     except Exception as e:
-        logger.exception("Export failed: %s", str(e))
+        logger.error("Export failed: %s", sanitize_for_logging(str(e)))
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=f"Export to {export_format} failed: {e!s}") from e
 
     # For HTML, we need to zip the output directory
@@ -560,7 +560,7 @@ async def export_document(
                     if persistent_temp_file.exists():
                         persistent_temp_file.unlink()
                 except Exception as e:
-                    logger.exception("Failed to clean up temporary file: %s", str(e))
+                    logger.error("Failed to clean up temporary file: %s", sanitize_for_logging(str(e)))
 
             # Record successful export metrics
             duration_ms = (time.perf_counter() - start_time) * 1000

--- a/app/strictdoc_controller.py
+++ b/app/strictdoc_controller.py
@@ -343,7 +343,7 @@ async def run_strictdoc_command(cmd: list[str]) -> None:
             stderr_text = stderr.decode("utf-8") if stderr else ""
             error_output = (stderr_text + "\n" + stdout_text).strip() or "Unknown error"
             logger.error("StrictDoc CLI error (returncode=%d): %s", process.returncode, sanitize_for_logging(error_output))
-            raise RuntimeError(f"StrictDoc command failed: {error_output}")
+            raise RuntimeError(f"StrictDoc command failed: {sanitize_for_logging(error_output)}")
 
         if stderr:
             stderr_text = stderr.decode("utf-8")

--- a/app/strictdoc_controller.py
+++ b/app/strictdoc_controller.py
@@ -342,12 +342,12 @@ async def run_strictdoc_command(cmd: list[str]) -> None:
             stdout_text = stdout.decode("utf-8") if stdout else ""
             stderr_text = stderr.decode("utf-8") if stderr else ""
             error_output = (stderr_text + "\n" + stdout_text).strip() or "Unknown error"
-            logger.error("StrictDoc CLI error (returncode=%d): %s", process.returncode, error_output)
+            logger.error("StrictDoc CLI error (returncode=%d): %s", process.returncode, sanitize_for_logging(error_output))
             raise RuntimeError(f"StrictDoc command failed: {error_output}")
 
         if stderr:
             stderr_text = stderr.decode("utf-8")
-            logger.warning("StrictDoc CLI warnings: %s", stderr_text)
+            logger.warning("StrictDoc CLI warnings: %s", sanitize_for_logging(stderr_text))
 
     except Exception as e:
         logger.exception("Command execution failed: %s", str(e))


### PR DESCRIPTION
## What

Sanitize all user-derived values that reach logging and exception sinks in `strictdoc_controller.py`, closing a class of **CWE-117 log injection** (and an incidental HTTP response-splitting vector). Every fixed sink routes the value through the existing `sanitize_for_logging()` helper (strips control chars incl. CR/LF, replaces newlines, truncates), matching the pattern already used for `cmd` args at the top of `run_strictdoc_command`.

## Why

StrictDoc echoes user-supplied SDOC content back in its stderr/stdout and parser errors. Several log/exception sinks recorded that data **raw**, so attacker-controlled CR/LF could forge log entries. The original scope was just the two subprocess log calls, but review (thanks @claude / @greptile-apps) surfaced that the same tainted data also escaped via the **exception chain** — embedded in `RuntimeError` messages and returned in HTTP error responses. This PR closes the whole class by sanitizing **at the source** (where tainted data enters a log call or an exception message).

## Changes

| Sink | Fix |
|------|-----|
| `logger.error` (error_output) | wrap in `sanitize_for_logging` |
| `RuntimeError` raise (subprocess) | sanitize at source — closes the re-raise chain + HTTP detail |
| `logger.warning` (stderr_text) | wrap in `sanitize_for_logging` |
| SDOC parse error | sanitize `error_msg` once for **both** the log and the client-facing `HTTPException` detail |

Because the exception **messages** are sanitized at their source, the surrounding `except` handlers keep the idiomatic `logger.exception()` (preserving tracebacks for debugging): the only user-controlled data their tracebacks can render is already clean. The one exception is the SDOC parse handler, which catches the **raw third-party parser exception** — there `logger.exception` would render unsanitized document content in the traceback, so it deliberately uses `logger.error` with the sanitized message (annotated `# NOSONAR S8572` with rationale in-code).

## Scope note

This is pre-existing code on `main`, **not** introduced by the in-flight feature PR that CodeQL happened to scan it under — hence a dedicated fix PR so it can merge independently.

## Testing

- `pytest tests/` → 104 unit tests pass (13 Docker-based integration tests error only because no Docker daemon is available locally — pre-existing, unrelated)
- pre-commit (ruff, mypy, commitizen, secret scans) clean

Resolves the `py/log-injection` code-scanning alert (#39) and hardens the surrounding sinks against the same class.
